### PR TITLE
feat: add a real readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
 # Newtonian
+
+## Technology
+Build System: [CMake](https://cmake.org/)
+Graphics Rendering: [Qt](https://www.qt.io/developers)
+Testing Framework: [GoogleTest](https://google.github.io/googletest/)
+
+## Conventions
+Branches should be created in a `name/type/change` format i.e: `joe/feature/add-readme`. refer to conventional commits for type names.
+Commit messages ideally follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) guidelines. This is optional for commits within a branch but it would be ideal to hold this convention for PR titles.
+<!-- TODO: determine snake- vs camel-case -->
+
+## Description
+Newtonian is a physics simulator designed to funciton as it's own entity separate from any graphics rendering tool. This grants the ability to abandon a graphics rendering technology if we so choose. This can be accomplished through using CMake and its target system to build Qt components, Newtonian components, or both.
+
+## Setup
+### macOs
+``` sh
+brew install cmake
+```
+
+### windows
+<!-- TODO: -->
+
+### linux
+<!-- TODO: -->

--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ to generate a build system within the specified directory. Then, cd into your ne
 cmake --build . --target <target>
 ```
 to generate your CMake generated project binary tree.
-```!Note
-If you are using VSCode, you can follow [this](https://learn.microsoft.com/en-us/vcpkg/get_started/get-started-vscode?pivots=shell-powershell) tutorial to build your projects using VSCode's built in tooling.
-```
+>[!TIP]
+>If you are using VSCode, you can follow [this](https://learn.microsoft.com/en-us/vcpkg/get_started/get-started-vscode?pivots=shell-powershell) tutorial to build your projects using VSCode's built in tooling.
 <!-- TODO: Expand when we have a concrete build process that can be documented -->

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 # Newtonian
-Newtonian is a physics simulator designed to a graphics rendering tool (in this implementation Qt). This grants a level of modularity that makes it easy to potentially occomidate other rendering engines in the future. This can be accomplished through using CMake and its target system to build Qt components, Newtonian components, or both.
+Newtonian is a physics simulator designed to use a graphics rendering tool (in this implementation Qt). This grants a level of modularity that makes it easy to potentially accomidate other rendering engines in the future. This can be accomplished through using CMake and its target system to build Qt components, Newtonian components, or both.
 
 ## Technology
-Primary Language: [C++](https://cplusplus.com/reference/)<br>
-Build System: [CMake](https://cmake.org/)<br>
-Graphics Rendering: [Qt](https://www.qt.io/developers)<br>
+Primary Language: [C++23](https://cplusplus.com/reference/)<br>
+Build System: [CMake](https://cmake.org/) (Minimum version 3.31)<br>
+Graphics Rendering: [Qt](https://www.qt.io/developers) (Version 6.8)<br>
 Testing Framework: [GoogleTest](https://google.github.io/googletest/)<br>
 
 ## Conventions
-Branches should be created in a `name/type/change` format i.e: `joe/feature/add-readme`. refer to conventional commits for branch type names.
+Commit messages ideally follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) guidelines. This is optional for commits within a branch but it would be ideal to hold this convention for PR titles to more easily parse commit history on the main branch.
 
-Commit messages ideally follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) guidelines. This is optional for commits within a branch but it would be ideal to hold this convention for PR titles.
+Branches should be created in a `name/type/change` format i.e: `joe/feature/add-readme`. refer to conventional commits for branch type names.
 
 ## Setup
 ### macOs
@@ -26,10 +26,7 @@ brew install cmake
 ### Linux
 <!-- TODO: -->
 
-## Use
-<!-- TODO: -->
-
-## Build from source
+## Build
 From within the root directory of the project run:
 ```sh
 cmake -B build
@@ -38,7 +35,10 @@ to generate a build system within the specified directory. Then, cd into your ne
 ```sh
 cmake --build . --target <target>
 ```
-to generate your CMake generated project binary tree.
+to generate your CMake generated project binary tree. To run the program, simply cd into the directory with the build target located within the build directory that we generated earlier and run the generated executable.
 >[!TIP]
 >If you are using VSCode, you can follow [this](https://learn.microsoft.com/en-us/vcpkg/get_started/get-started-vscode?pivots=shell-powershell) tutorial to build your projects using VSCode's built in tooling.
 <!-- TODO: Expand when we have a concrete build process that can be documented -->
+
+## Use
+<!-- TODO: -->

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Newtonian
 
 ## Technology
-Build System: [CMake](https://cmake.org/)
-Graphics Rendering: [Qt](https://www.qt.io/developers)
-Testing Framework: [GoogleTest](https://google.github.io/googletest/)
+Build System: [CMake](https://cmake.org/)<br>
+Graphics Rendering: [Qt](https://www.qt.io/developers)<br>
+Testing Framework: [GoogleTest](https://google.github.io/googletest/)<br>
 
 ## Conventions
 Branches should be created in a `name/type/change` format i.e: `joe/feature/add-readme`. refer to conventional commits for type names.

--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
 # Newtonian
+Newtonian is a physics simulator designed to funciton as it's own entity separate from any graphics rendering tool. This grants the ability to abandon a graphics rendering technology if we so choose. This can be accomplished through using CMake and its target system to build Qt components, Newtonian components, or both.
 
 ## Technology
+Primary Language: [C++](https://cplusplus.com/reference/)<br>
 Build System: [CMake](https://cmake.org/)<br>
 Graphics Rendering: [Qt](https://www.qt.io/developers)<br>
 Testing Framework: [GoogleTest](https://google.github.io/googletest/)<br>
 
 ## Conventions
-Branches should be created in a `name/type/change` format i.e: `joe/feature/add-readme`. refer to conventional commits for type names.
+Branches should be created in a `name/type/change` format i.e: `joe/feature/add-readme`. refer to conventional commits for branch type names.
+
 Commit messages ideally follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) guidelines. This is optional for commits within a branch but it would be ideal to hold this convention for PR titles.
 <!-- TODO: determine snake- vs camel-case -->
-
-## Description
-Newtonian is a physics simulator designed to funciton as it's own entity separate from any graphics rendering tool. This grants the ability to abandon a graphics rendering technology if we so choose. This can be accomplished through using CMake and its target system to build Qt components, Newtonian components, or both.
 
 ## Setup
 ### macOs

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Newtonian
-Newtonian is a physics simulator designed to funciton as it's own entity separate from any graphics rendering tool. This grants the ability to abandon a graphics rendering technology if we so choose. This can be accomplished through using CMake and its target system to build Qt components, Newtonian components, or both.
+Newtonian is a physics simulator designed to a graphics rendering tool (in this implementation Qt). This grants a level of modularity that makes it easy to potentially occomidate other rendering engines in the future. This can be accomplished through using CMake and its target system to build Qt components, Newtonian components, or both.
 
 ## Technology
 Primary Language: [C++](https://cplusplus.com/reference/)<br>
@@ -11,16 +11,35 @@ Testing Framework: [GoogleTest](https://google.github.io/googletest/)<br>
 Branches should be created in a `name/type/change` format i.e: `joe/feature/add-readme`. refer to conventional commits for branch type names.
 
 Commit messages ideally follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) guidelines. This is optional for commits within a branch but it would be ideal to hold this convention for PR titles.
-<!-- TODO: determine snake- vs camel-case -->
 
 ## Setup
 ### macOs
+Ensure that [Homebrew](https://brew.sh/) is installed.<br>
+Within your terminal run:
 ``` sh
 brew install cmake
 ```
 
-### windows
+### Windows
 <!-- TODO: -->
 
-### linux
+### Linux
 <!-- TODO: -->
+
+## Use
+<!-- TODO: -->
+
+## Build from source
+From within the root directory of the project run:
+```sh
+cmake -B build
+```
+to generate a build system within the specified directory. Then, cd into your new build directory located at the root of your project and run:
+```sh
+cmake --build . --target <target>
+```
+to generate your CMake generated project binary tree.
+```!Note
+If you are using VSCode, you can follow [this](https://learn.microsoft.com/en-us/vcpkg/get_started/get-started-vscode?pivots=shell-powershell) tutorial to build your projects using VSCode's built in tooling.
+```
+<!-- TODO: Expand when we have a concrete build process that can be documented -->


### PR DESCRIPTION
All of this is up for debate. If we want to use more relaxed conventions, we can do that, this is just using my normal workflow. Any thoughts can be commented in the PR so that everyone can play with the interface for this. Work still needs to be done on the linux and windows setup subsections regarding CMake. I don't expect for the `Use` section to be filled out until the project begins to take a more coherent shape.