### PR TITLE
feat: added exporting to CSV

### DIFF
--- a/src/ui/replayTable/replayTable.hpp
+++ b/src/ui/replayTable/replayTable.hpp
@@ -4,11 +4,16 @@
 #include <iostream>
 #include <vector>
 #include <map>
+#include <fstream>
+#include <sstream>
 #include <variant>
 
 // create aliases for table structure
 using value = std::variant<int, double, std::string, float>;
 using attributeMap = std::map<std::string, value>;
+
+// Function to convert variant to string
+std::string variantToString(const value& val);
 
 // example test object
 class testObject{
@@ -29,6 +34,8 @@ class replayTable{
         void addRow(const attributeMap& newData);
         // print out the table
         void printTable() const;
+        void reset();
+        void exportCSV(const std::string& filename) const;
 };
 
 class replayTableUpdater{

--- a/src/ui/replayTable/replayTableMain.cpp
+++ b/src/ui/replayTable/replayTableMain.cpp
@@ -21,6 +21,9 @@ int main() {
     }
 
     table.printTable();  // print table
+    table.exportCSV("replayData.csv");
+    table.reset();
+    table.printTable();
     return 0;
 }
 


### PR DESCRIPTION
Added method to export replayTable to a CSV file.
Added reset method to replayTable to clear the table
Added function to convert a variant to a string
Changed replayTableUpdater to store the timestamp in each row of the table