### PR TITLE
feat: add vector operator overloads

### DIFF
--- a/lib/vector3d/test/vector3d_test.cpp
+++ b/lib/vector3d/test/vector3d_test.cpp
@@ -1,4 +1,5 @@
 #include "gtest/gtest.h"
+#include <cmath>
 #include <gtest/gtest.h>
 #include "rigidBody.hpp"
 #include "vector3d.hpp"
@@ -113,6 +114,43 @@ TEST_F(Vector3dTest, DivisionOverload) {
 	ASSERT_FLOAT_EQ(expected.x, (v1/scalar).x);
 	ASSERT_FLOAT_EQ(expected.y, (v1/scalar).y);
 	ASSERT_FLOAT_EQ(expected.z, (v1/scalar).z);
+}
+
+TEST_F(Vector3dTest, Normalize) {
+	Vector3d vec = v1;
+	v1.normalize();
+	
+	float mag = std::sqrt(
+		(vec.x * vec.x) +
+		(vec.y * vec.y) +
+		(vec.z * vec.z)
+	);
+
+	float xNormd = vec.x / mag;
+	float yNormd = vec.y / mag;
+	float zNormd = vec.z / mag;
+
+	ASSERT_FLOAT_EQ(xNormd, v1.x);
+	ASSERT_FLOAT_EQ(yNormd, v1.y);
+	ASSERT_FLOAT_EQ(zNormd, v1.z);
+
+	// Calculated via calculator
+	ASSERT_FLOAT_EQ(0.2672612419f, v1.x);
+	ASSERT_FLOAT_EQ(0.53452248382485f, v1.y);
+	ASSERT_FLOAT_EQ(0.80178372573727f, v1.z);
+}
+
+TEST_F(Vector3dTest, Normalized) {
+	Vector3d normd = v1.normalized();
+
+	// Calculated via calculator
+	ASSERT_FLOAT_EQ(0.2672612419f, normd.x);
+	ASSERT_FLOAT_EQ(0.53452248382485f, normd.y);
+	ASSERT_FLOAT_EQ(0.80178372573727f, normd.z);
+
+	ASSERT_FLOAT_EQ(10.0f, v1.x);
+	ASSERT_FLOAT_EQ(20.0f, v1.y);
+	ASSERT_FLOAT_EQ(30.0f, v1.z);
 }
 
 int main(int argc, char **argv) {

--- a/lib/vector3d/test/vector3d_test.cpp
+++ b/lib/vector3d/test/vector3d_test.cpp
@@ -1,6 +1,7 @@
 #include "gtest/gtest.h"
 #include <gtest/gtest.h>
 #include "rigidBody.hpp"
+#include "vector3d.hpp"
 
 class Vector3dTest : public ::testing::Test {
 protected:
@@ -61,6 +62,58 @@ TEST_F(Vector3dTest, Magnitude) {
 	GTEST_SKIP();
 }
 
+TEST_F(Vector3dTest, AdditionOverload) {
+	Vector3d vec = Vector3d(5, 5, 5);
+	Vector3d expected = Vector3d(15, 25, 35);
+
+	ASSERT_FLOAT_EQ(expected.x, (v1+vec).x);
+	ASSERT_FLOAT_EQ(expected.y, (v1+vec).y);
+	ASSERT_FLOAT_EQ(expected.z, (v1+vec).z);
+}
+
+TEST_F(Vector3dTest, SubtractionOverload) {
+	Vector3d vec = Vector3d(10.0f, 1.0f, 14.0f);
+	Vector3d expected = Vector3d(0.0f, 19.0f, 16.0f);
+
+	ASSERT_FLOAT_EQ(expected.x, (v1-vec).x);
+	ASSERT_FLOAT_EQ(expected.y, (v1-vec).y);
+	ASSERT_FLOAT_EQ(expected.z, (v1-vec).z);
+}
+
+TEST_F(Vector3dTest, NegationOverload) {
+	Vector3d expected = Vector3d(-10.0f, -20.0f, -30.0f);
+	
+	ASSERT_FLOAT_EQ(expected.x, -v1.x);
+	ASSERT_FLOAT_EQ(expected.y, -v1.y);
+	ASSERT_FLOAT_EQ(expected.z, -v1.z);
+}
+
+TEST_F(Vector3dTest, MultiplacationOverload) {
+	Vector3d expected = Vector3d(30.0f, 60.0f, 90.0f);
+	float scalar = 3.0f;
+
+	ASSERT_FLOAT_EQ(expected.x, (v1*scalar).x);
+	ASSERT_FLOAT_EQ(expected.y, (v1*scalar).y);
+	ASSERT_FLOAT_EQ(expected.z, (v1*scalar).z);
+}
+
+TEST_F(Vector3dTest, MultiplacationOverloadReverseOrder) {
+	Vector3d expected = Vector3d(30.0f, 60.0f, 90.0f);
+	float scalar = 3.0f;
+
+	ASSERT_FLOAT_EQ(expected.x, (scalar*v1).x);
+	ASSERT_FLOAT_EQ(expected.y, (scalar*v1).y);
+	ASSERT_FLOAT_EQ(expected.z, (scalar*v1).z);
+}
+
+TEST_F(Vector3dTest, DivisionOverload) {
+	Vector3d expected = Vector3d(2.0f, 4.0f, 6.0f);
+	float scalar = 5.0f;
+
+	ASSERT_FLOAT_EQ(expected.x, (v1/scalar).x);
+	ASSERT_FLOAT_EQ(expected.y, (v1/scalar).y);
+	ASSERT_FLOAT_EQ(expected.z, (v1/scalar).z);
+}
 
 int main(int argc, char **argv) {
   testing::InitGoogleTest(&argc, argv);

--- a/lib/vector3d/vector3d.cpp
+++ b/lib/vector3d/vector3d.cpp
@@ -1,10 +1,51 @@
 #include "vector3d.hpp"
 #include <cmath>
+#include <stdexcept>
 
 Vector3d::Vector3d(float x, float y, float z): x(0), y(0), z(0) {
 	this->x = x;
 	this->y = y;
 	this->z = z;
+}
+
+Vector3d Vector3d::operator+(const Vector3d& vec) const {
+	return Vector3d(
+		this->x + vec.x,
+		this->y + vec.y,
+		this->z + vec.z
+	);
+}
+
+Vector3d Vector3d::operator-(const Vector3d& vec) const {
+	return Vector3d(
+		this->x - vec.x,
+		this->y - vec.y,
+		this->z - vec.z
+	);
+}
+
+Vector3d Vector3d::operator*(float scalar) const {
+	return Vector3d(
+		this->x * scalar,
+		this->y * scalar,
+		this->z * scalar
+	);
+}
+
+Vector3d operator*(float scalar, const Vector3d& vec) {
+	return vec * scalar;
+}
+
+Vector3d Vector3d::operator/(float scalar) const {
+	if (scalar != 0) {
+		return Vector3d(
+			this->x / scalar,
+			this->y / scalar,
+			this->z / scalar
+		);
+	}
+
+	throw std::overflow_error("Divide by zero exception");
 }
 
 // internal X vec

--- a/lib/vector3d/vector3d.cpp
+++ b/lib/vector3d/vector3d.cpp
@@ -69,15 +69,24 @@ Vector3d Vector3d::projectOnto(const Vector3d& vec) {
 	return (dot / magSqrd) * vec;
 }
 
-Vector3d Vector3d::normalize() {
+void Vector3d::normalize() {
+	float magnitude = this->magnitude();
+
+	this->x /= magnitude;
+	this->y /= magnitude;
+	this->z /= magnitude;
+}
+
+Vector3d Vector3d::normalized() {
 	float magnitude = this->magnitude();
 
 	return Vector3d(
 		this->x / magnitude,
 		this->y / magnitude,
-		this->z / magnitude
+		this->z / magnitude,
 	);
 }
+
 
 float Vector3d::dotProduct(const Vector3d& vec) {
 	 return (this->x * vec.x) + (this->y * vec.y) + (this->z * vec.z);

--- a/lib/vector3d/vector3d.cpp
+++ b/lib/vector3d/vector3d.cpp
@@ -24,6 +24,10 @@ Vector3d Vector3d::operator-(const Vector3d& vec) const {
 	);
 }
 
+Vector3d Vector3d::operator-() const {
+	return Vector3d(-this->x, -this->y, -this->z);
+}
+
 Vector3d Vector3d::operator*(float scalar) const {
 	return Vector3d(
 		this->x * scalar,
@@ -55,6 +59,24 @@ Vector3d Vector3d::crossProduct(const Vector3d& vec) {
 	float k = (this->x * vec.y) - (this->y * vec.x);
 
 	return Vector3d(i, j, k);
+}
+
+Vector3d Vector3d::projectOnto(const Vector3d& vec) {
+	float dot = this->dotProduct(vec);
+	float sum = std::pow(vec.x, 2) + std::pow(vec.y, 2) + std::pow(vec.z, 2);
+	float magSqrd = std::sqrt(sum) * std::sqrt(sum);
+
+	return (dot / magSqrd) * vec;
+}
+
+Vector3d Vector3d::normalize() {
+	float magnitude = this->magnitude();
+
+	return Vector3d(
+		this->x / magnitude,
+		this->y / magnitude,
+		this->z / magnitude
+	);
 }
 
 float Vector3d::dotProduct(const Vector3d& vec) {

--- a/lib/vector3d/vector3d.cpp
+++ b/lib/vector3d/vector3d.cpp
@@ -80,11 +80,7 @@ void Vector3d::normalize() {
 Vector3d Vector3d::normalized() {
 	float magnitude = this->magnitude();
 
-	return Vector3d(
-		this->x / magnitude,
-		this->y / magnitude,
-		this->z / magnitude,
-	);
+	return Vector3d(this->x, this->y, this->z) / magnitude;
 }
 
 

--- a/lib/vector3d/vector3d.hpp
+++ b/lib/vector3d/vector3d.hpp
@@ -11,7 +11,18 @@ public:
 	float y;
 	float z;
 
+	Vector3d operator+(const Vector3d& vec) const;
+	Vector3d operator-(const Vector3d& vec) const;
+	Vector3d operator*(float scalar) const;
+	friend Vector3d operator*(float scalar, const Vector3d& vec);
+	Vector3d operator/(float scalar) const;
+
 	Vector3d crossProduct(const Vector3d& vec);
+	Vector3d projectOnto(const Vector3d& vec);
+	Vector3d normalize();
+	Vector3d reflect();
+	Vector3d negate();
+
 	float dotProduct(const Vector3d& vec);
 	float magnitude();
 

--- a/lib/vector3d/vector3d.hpp
+++ b/lib/vector3d/vector3d.hpp
@@ -13,6 +13,7 @@ public:
 
 	Vector3d operator+(const Vector3d& vec) const;
 	Vector3d operator-(const Vector3d& vec) const;
+	Vector3d operator-() const;
 	Vector3d operator*(float scalar) const;
 	friend Vector3d operator*(float scalar, const Vector3d& vec);
 	Vector3d operator/(float scalar) const;
@@ -20,7 +21,7 @@ public:
 	Vector3d crossProduct(const Vector3d& vec);
 	Vector3d projectOnto(const Vector3d& vec);
 	Vector3d normalize();
-	Vector3d reflect();
+	Vector3d reflect(); // TODO: implement this
 	Vector3d negate();
 
 	float dotProduct(const Vector3d& vec);

--- a/lib/vector3d/vector3d.hpp
+++ b/lib/vector3d/vector3d.hpp
@@ -20,12 +20,13 @@ public:
 
 	Vector3d crossProduct(const Vector3d& vec);
 	Vector3d projectOnto(const Vector3d& vec);
-	Vector3d normalize();
+	Vector3d normalized();
 	Vector3d reflect(); // TODO: implement this
-	Vector3d negate();
 
 	float dotProduct(const Vector3d& vec);
 	float magnitude();
+
+	void normalize();
 
 	// TODO:: https://people.math.harvard.edu/~jjchen/math21a/handouts/vector-ops.html
 	// - [ ] Vector addition


### PR DESCRIPTION
adds operator overloads for the `Vector3d` class

Allows for easy programatic vector arithmetic operations such as addition and subtraction without accessing vector components.
Also adds normalization methods for returning a new, normalized instance of the target vector, and a method for normalizing the vector itself.
Includes unit tests